### PR TITLE
南粤银行编码问题修复，未配置编码引起异常

### DIFF
--- a/src/BankCard.php
+++ b/src/BankCard.php
@@ -36,7 +36,7 @@ class BankCard
         "HKB"       => "汉口银行",
         "SPDB"      => "上海浦东发展银行",
         "NXRCU"     => "宁夏黄河农村商业银行",
-        "NYNB"      => "广东南粤银行",
+        "NYBANK"    => "广东南粤银行",
         "GRCB"      => "广州农商银行",
         "BOSZ"      => "苏州银行",
         "HZCB"      => "杭州银行",
@@ -204,15 +204,15 @@ class BankCard
             );
         } else {
             $bankInfo = array(
-                'validated' => $result->validated,              // 是否验证通过
-                'bank' => $result->bank,                        // 银行代码
-                'bankName' => self::$bankInfo[$result->bank],   // 银行名称
-                'bankImg' => self::getBankImg($result->bank),
-                'cardType' => $result->cardType,                // 银行卡类型, CC 信用卡, DC 储蓄卡
+                'validated'    => $result->validated,              // 是否验证通过
+                'bank'         => $result->bank,                        // 银行代码
+                'bankName'     => isset(self::$bankInfo[$result->bank]) ? self::$bankInfo[$result->bank] : '',   // 银行名称
+                'bankImg'      => self::getBankImg($result->bank),
+                'cardType'     => $result->cardType,                // 银行卡类型, CC 信用卡, DC 储蓄卡
                 'cardTypeName' => self::$cardType[$result->cardType],
             );
         }
-        
+
         return $bankInfo;
     }
 }


### PR DESCRIPTION
1. 南粤银行编码更新
2. 当编码未配置时，不应该抛出异常，如果判断一下，只有银行名称不可用，其他的信息，如信用卡，储蓄卡，信息还是可以用的。
